### PR TITLE
Define local Yahoo Finance quote type

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+# Environment variables for Stocks tracking application
+# Obtain an API key from Financial Modeling Prep and set it below.
+FMP_API_KEY=your_fmp_api_key_here

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,4 @@
 import { DataTable } from "@/components/stocks/markets/data-table"
-import yahooFinance from "yahoo-finance2"
 import {
   Card,
   CardContent,
@@ -19,6 +18,7 @@ import {
   validateRange,
 } from "@/lib/yahoo-finance/fetchChartData"
 import { fetchStockSearch } from "@/lib/yahoo-finance/fetchStockSearch"
+import { fetchQuote } from "@/lib/yahoo-finance/fetchQuote"
 
 function isMarketOpen() {
   const now = new Date()
@@ -106,15 +106,14 @@ export default async function Home({
     (searchParams?.interval as Interval) || DEFAULT_INTERVAL
   )
   const news = await fetchStockSearch("^DJI", 1)
+  const firstNews = news.news?.[0]
 
-  const promises = tickers.map(({ symbol }) =>
-    yahooFinance.quoteCombine(symbol)
-  )
+  const promises = tickers.map(({ symbol }) => fetchQuote(symbol))
   const results = await Promise.all(promises)
 
   const resultsWithTitles = results.map((result, index) => ({
     ...result,
-    shortName: tickers[index].shortName,
+    shortName: tickers[index].shortName ?? result.shortName,
   }))
 
   const marketSentiment = getMarketSentiment(
@@ -146,17 +145,17 @@ export default async function Home({
                 <strong className={sentimentColor}>{marketSentiment}</strong>
               </CardTitle>
             </CardHeader>
-            {news.news[0] && news.news[0].title && (
+            {firstNews && firstNews.title && (
               <CardFooter className="flex-col items-start">
                 <p className="mb-2 text-sm font-semibold text-neutral-500 dark:text-neutral-500">
                   What you need to know today
                 </p>
                 <Link
                   prefetch={false}
-                  href={news.news[0].link}
+                  href={firstNews.link}
                   className="text-lg font-extrabold"
                 >
-                  {news.news[0].title}
+                  {firstNews.title}
                 </Link>
               </CardFooter>
             )}

--- a/app/stocks/[ticker]/components/CompanySummaryCard.tsx
+++ b/app/stocks/[ticker]/components/CompanySummaryCard.tsx
@@ -1,16 +1,14 @@
-import yahooFinance from "yahoo-finance2"
 import { Card, CardContent } from "../../../../components/ui/card"
 import ReadMoreText from "../../../../components/ui/read-more-text"
 import Link from "next/link"
+import { fetchQuoteSummary } from "@/lib/yahoo-finance/fetchQuoteSummary"
 
 export default async function CompanySummaryCard({
   ticker,
 }: {
   ticker: string
 }) {
-  const data = await yahooFinance.quoteSummary(ticker, {
-    modules: ["summaryProfile"],
-  })
+  const data = await fetchQuoteSummary(ticker)
 
   if (!data.summaryProfile) {
     return null

--- a/app/stocks/[ticker]/components/News.tsx
+++ b/app/stocks/[ticker]/components/News.tsx
@@ -6,7 +6,7 @@ import {
   differenceInDays,
 } from "date-fns"
 
-function timeAgo(publishTime: string) {
+function timeAgo(publishTime: string | Date) {
   const publishDate = new Date(publishTime)
   const now = new Date()
 
@@ -25,16 +25,17 @@ function timeAgo(publishTime: string) {
 
 export default async function News({ ticker }: { ticker: string }) {
   const newsData = await fetchStockSearch(ticker)
+  const articles = newsData.news ?? []
   const url = `https://uk.finance.yahoo.com/quote/${ticker}`
 
   return (
     <div className="w-4/5">
-      {newsData.news.length === 0 && (
+      {articles.length === 0 && (
         <div className="py-4 text-center text-sm font-medium text-muted-foreground">
           No Recent Stories
         </div>
       )}
-      {newsData.news.length > 0 && (
+      {articles.length > 0 && (
         <>
           <Link
             href={url}
@@ -60,7 +61,7 @@ export default async function News({ ticker }: { ticker: string }) {
             </i>
           </Link>
           <div className="flex flex-col gap-2">
-            {newsData.news.map((article) => (
+            {articles.map((article) => (
               <Link
                 key={article.uuid}
                 href={article.link}
@@ -69,7 +70,7 @@ export default async function News({ ticker }: { ticker: string }) {
               >
                 <span className="text-sm font-medium text-muted-foreground">
                   {article.publisher} -{" "}
-                  {timeAgo(article.providerPublishTime.toISOString())}
+                  {timeAgo(article.providerPublishTime)}
                 </span>
                 <span className="font-semibold">{article.title}</span>
                 <span className="text-sm font-medium text-muted-foreground">

--- a/components/chart/StockChart.tsx
+++ b/components/chart/StockChart.tsx
@@ -2,7 +2,6 @@ import { cn } from "@/lib/utils"
 import { fetchChartData } from "@/lib/yahoo-finance/fetchChartData"
 import type { Interval, Range } from "@/types/yahoo-finance"
 import AreaClosedChart from "./AreaClosedChart"
-import yahooFinance from "yahoo-finance2"
 import { fetchQuote } from "@/lib/yahoo-finance/fetchQuote"
 
 interface StockGraphProps {

--- a/components/stocks/markets/columns.tsx
+++ b/components/stocks/markets/columns.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { ColumnDef } from "@tanstack/react-table"
-import type { Quote } from "@/node_modules/yahoo-finance2/dist/esm/src/modules/quote"
+import type { Quote } from "@/types/yahoo-finance"
 import { cn } from "@/lib/utils"
 import Link from "next/link"
 

--- a/lib/fmp/client.ts
+++ b/lib/fmp/client.ts
@@ -1,0 +1,41 @@
+const FMP_BASE_URL = "https://financialmodelingprep.com/api/v3"
+
+type QueryParams = Record<string, string | number | undefined>
+
+function buildUrl(path: string, params: QueryParams = {}): string {
+  const apiKey = process.env.FMP_API_KEY
+
+  if (!apiKey) {
+    throw new Error(
+      "FMP_API_KEY is not set. Please configure the API key in your environment."
+    )
+  }
+
+  const url = new URL(path, FMP_BASE_URL)
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      url.searchParams.set(key, String(value))
+    }
+  })
+
+  url.searchParams.set("apikey", apiKey)
+
+  return url.toString()
+}
+
+export async function fmpFetch<T>(path: string, params: QueryParams = {}): Promise<T> {
+  const url = buildUrl(path, params)
+
+  const response = await fetch(url, {
+    next: {
+      revalidate: 60,
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`FMP request failed with status ${response.status}`)
+  }
+
+  return (await response.json()) as T
+}

--- a/lib/fmp/news.ts
+++ b/lib/fmp/news.ts
@@ -1,0 +1,59 @@
+import { fmpFetch } from "./client"
+
+type FmpNewsResponse = FmpNewsArticle[]
+
+interface FmpNewsArticle {
+  symbol: string
+  publishedDate: string
+  title: string
+  image?: string
+  site?: string
+  text?: string
+  url: string
+}
+
+export interface StockNewsArticle {
+  id: string
+  uuid: string
+  title: string
+  link: string
+  publisher: string
+  providerPublishTime: Date
+  published_at: string
+}
+
+export interface StockNewsResult {
+  news: StockNewsArticle[]
+}
+
+function mapNewsArticle(article: FmpNewsArticle): StockNewsArticle {
+  const publishedDate = new Date(article.publishedDate)
+
+  return {
+    id: article.url,
+    uuid: article.url,
+    title: article.title,
+    link: article.url,
+    publisher: article.site ?? "",
+    providerPublishTime: publishedDate,
+    published_at: article.publishedDate,
+  }
+}
+
+export async function fetchFmpNews(
+  ticker: string,
+  limit: number
+): Promise<StockNewsResult> {
+  const response = await fmpFetch<FmpNewsResponse>("stock_news", {
+    tickers: ticker,
+    limit,
+  })
+
+  if (!Array.isArray(response)) {
+    return { news: [] }
+  }
+
+  return {
+    news: response.map(mapNewsArticle),
+  }
+}

--- a/lib/fmp/quoteSummary.ts
+++ b/lib/fmp/quoteSummary.ts
@@ -1,0 +1,72 @@
+import { fmpFetch } from "./client"
+import { fetchFmpQuote } from "./quotes"
+import type { Quote, QuoteSummary } from "@/types/yahoo-finance"
+
+interface FmpProfile {
+  symbol: string
+  beta?: number
+  lastDiv?: number
+  website?: string
+  description?: string
+  sector?: string
+  industry?: string
+  country?: string
+  fullTimeEmployees?: number
+}
+
+type FmpProfileResponse = FmpProfile[]
+
+function buildSummaryDetail(quote: Quote, profile?: FmpProfile) {
+  const price = quote.regularMarketPrice
+  const lastDividend = profile?.lastDiv
+
+  return {
+    open: quote.regularMarketOpen,
+    dayHigh: quote.regularMarketDayHigh,
+    dayLow: quote.regularMarketDayLow,
+    volume: quote.regularMarketVolume,
+    trailingPE: quote.trailingPE,
+    marketCap: quote.marketCap,
+    fiftyTwoWeekHigh: quote.fiftyTwoWeekHigh,
+    fiftyTwoWeekLow: quote.fiftyTwoWeekLow,
+    averageVolume: quote.averageDailyVolume3Month,
+    dividendYield: price && lastDividend ? lastDividend / price : undefined,
+    beta: profile?.beta,
+  }
+}
+
+function buildDefaultKeyStatistics(quote: Quote) {
+  return {
+    trailingEps: quote.trailingEps,
+  }
+}
+
+function buildSummaryProfile(profile?: FmpProfile) {
+  if (!profile) {
+    return undefined
+  }
+
+  return {
+    longBusinessSummary: profile.description,
+    sector: profile.sector,
+    industryDisp: profile.industry,
+    country: profile.country,
+    fullTimeEmployees: profile.fullTimeEmployees,
+    website: profile.website,
+  }
+}
+
+export async function fetchFmpQuoteSummary(ticker: string): Promise<QuoteSummary> {
+  const [quote, profileResponse] = await Promise.all([
+    fetchFmpQuote(ticker),
+    fmpFetch<FmpProfileResponse>(`profile/${ticker}`).catch(() => []),
+  ])
+
+  const profile = Array.isArray(profileResponse) ? profileResponse[0] : undefined
+
+  return {
+    summaryDetail: buildSummaryDetail(quote, profile),
+    defaultKeyStatistics: buildDefaultKeyStatistics(quote),
+    summaryProfile: buildSummaryProfile(profile),
+  }
+}

--- a/lib/fmp/quotes.ts
+++ b/lib/fmp/quotes.ts
@@ -1,0 +1,104 @@
+import type { Quote } from "@/types/yahoo-finance"
+import { fmpFetch } from "./client"
+
+interface FmpQuote {
+  symbol: string
+  name?: string
+  price?: number
+  change?: number
+  changesPercentage?: number
+  dayLow?: number
+  dayHigh?: number
+  yearLow?: number
+  yearHigh?: number
+  marketCap?: number
+  volume?: number
+  avgVolume?: number
+  open?: number
+  previousClose?: number
+  eps?: number
+  pe?: number
+  exchange?: string
+  currency?: string
+  timestamp?: number
+  postMarketPrice?: number
+  postMarketChange?: number
+  postMarketChangePercent?: number
+  preMarketPrice?: number
+  preMarketChange?: number
+  preMarketChangePercent?: number
+}
+
+type FmpQuoteResponse = FmpQuote[]
+
+function mapFmpQuoteToQuote(fmpQuote: FmpQuote): Quote {
+  const {
+    symbol,
+    name,
+    price,
+    change,
+    changesPercentage,
+    dayLow,
+    dayHigh,
+    yearLow,
+    yearHigh,
+    marketCap,
+    volume,
+    avgVolume,
+    open,
+    previousClose,
+    eps,
+    pe,
+    exchange,
+    currency,
+    timestamp,
+    postMarketPrice,
+    postMarketChange,
+    postMarketChangePercent,
+    preMarketPrice,
+    preMarketChange,
+    preMarketChangePercent,
+  } = fmpQuote
+
+  const mappedQuote: Quote = {
+    symbol,
+    shortName: name ?? symbol,
+    regularMarketPrice: price,
+    regularMarketChange: change,
+    regularMarketChangePercent: changesPercentage,
+    regularMarketDayLow: dayLow,
+    regularMarketDayHigh: dayHigh,
+    fiftyTwoWeekLow: yearLow,
+    fiftyTwoWeekHigh: yearHigh,
+    marketCap,
+    regularMarketVolume: volume,
+    averageDailyVolume3Month: avgVolume,
+    regularMarketOpen: open,
+    regularMarketPreviousClose: previousClose,
+    trailingEps: eps,
+    trailingPE: pe,
+    fullExchangeName: exchange,
+    currency,
+    regularMarketTime: timestamp,
+    postMarketPrice,
+    postMarketChange,
+    postMarketChangePercent,
+    preMarketPrice,
+    preMarketChange,
+    preMarketChangePercent,
+    hasPrePostMarketData:
+      postMarketPrice !== undefined || preMarketPrice !== undefined,
+  }
+
+  return mappedQuote
+}
+
+export async function fetchFmpQuote(ticker: string): Promise<Quote> {
+  const response = await fmpFetch<FmpQuoteResponse>(`quote/${ticker}`)
+
+  if (!Array.isArray(response) || response.length === 0) {
+    throw new Error(`No quote data returned for ticker ${ticker}`)
+  }
+
+  return mapFmpQuoteToQuote(response[0])
+}

--- a/lib/yahoo-finance/fetchQuote.ts
+++ b/lib/yahoo-finance/fetchQuote.ts
@@ -1,5 +1,6 @@
 import { unstable_noStore as noStore } from "next/cache"
 import yahooFinance from "yahoo-finance2"
+import { fetchFmpQuote } from "@/lib/fmp/quotes"
 
 export async function fetchQuote(ticker: string) {
   noStore()
@@ -10,6 +11,12 @@ export async function fetchQuote(ticker: string) {
     return response
   } catch (error) {
     console.log("Failed to fetch stock quote", error)
-    throw new Error("Failed to fetch stock quote.")
+
+    try {
+      return await fetchFmpQuote(ticker)
+    } catch (fallbackError) {
+      console.log("Fallback quote fetch failed", fallbackError)
+      throw new Error("Failed to fetch stock quote.")
+    }
   }
 }

--- a/lib/yahoo-finance/fetchQuoteSummary.ts
+++ b/lib/yahoo-finance/fetchQuoteSummary.ts
@@ -1,17 +1,25 @@
 import { unstable_noStore as noStore } from "next/cache"
 import yahooFinance from "yahoo-finance2"
+import { fetchFmpQuoteSummary } from "@/lib/fmp/quoteSummary"
+import type { QuoteSummary } from "@/types/yahoo-finance"
 
-export async function fetchQuoteSummary(ticker: string) {
+export async function fetchQuoteSummary(ticker: string): Promise<QuoteSummary> {
   noStore()
 
   try {
     const response = await yahooFinance.quoteSummary(ticker, {
-      modules: ["summaryDetail", "defaultKeyStatistics"],
+      modules: ["summaryDetail", "defaultKeyStatistics", "summaryProfile"],
     })
 
     return response
   } catch (error) {
     console.log("Failed to fetch quote summary", error)
-    throw new Error("Failed to fetch quote summary.")
+
+    try {
+      return await fetchFmpQuoteSummary(ticker)
+    } catch (fallbackError) {
+      console.log("Fallback quote summary fetch failed", fallbackError)
+      throw new Error("Failed to fetch quote summary.")
+    }
   }
 }

--- a/lib/yahoo-finance/fetchStockSearch.ts
+++ b/lib/yahoo-finance/fetchStockSearch.ts
@@ -1,8 +1,16 @@
 import { unstable_noStore as noStore } from "next/cache"
 import yahooFinance from "yahoo-finance2"
-import type { SearchResult } from "@/node_modules/yahoo-finance2/dist/esm/src/modules/search"
+import type {
+  SearchNews,
+  SearchResult,
+} from "@/node_modules/yahoo-finance2/dist/esm/src/modules/search"
+import { fetchFmpNews } from "@/lib/fmp/news"
+import type { StockNewsResult } from "@/lib/fmp/news"
 
-export async function fetchStockSearch(ticker: string, newsCount: number = 5) {
+export async function fetchStockSearch(
+  ticker: string,
+  newsCount: number = 5
+): Promise<StockNewsResult> {
   noStore()
 
   const queryOptions = {
@@ -17,9 +25,31 @@ export async function fetchStockSearch(ticker: string, newsCount: number = 5) {
       queryOptions
     )
 
-    return response
+    const mappedNews = Array.isArray(response.news)
+      ? response.news.map(mapYahooNewsArticle)
+      : []
+
+    return { news: mappedNews }
   } catch (error) {
     console.log("Failed to fetch stock search", error)
-    throw new Error("Failed to fetch stock search.")
+
+    try {
+      return await fetchFmpNews(ticker, newsCount)
+    } catch (fallbackError) {
+      console.log("Fallback stock news fetch failed", fallbackError)
+      return { news: [] }
+    }
+  }
+}
+
+function mapYahooNewsArticle(article: SearchNews) {
+  return {
+    id: article.uuid,
+    uuid: article.uuid,
+    title: article.title,
+    link: article.link,
+    publisher: article.publisher,
+    providerPublishTime: article.providerPublishTime,
+    published_at: article.providerPublishTime.toISOString(),
   }
 }

--- a/types/yahoo-finance.ts
+++ b/types/yahoo-finance.ts
@@ -31,3 +31,59 @@ export type Interval =
   | "1wk"
   | "1mo"
   | "3mo";
+
+export interface Quote {
+  symbol: string
+  shortName?: string | null
+  regularMarketPrice?: number | null
+  regularMarketChange?: number | null
+  regularMarketChangePercent?: number | null
+  regularMarketDayLow?: number | null
+  regularMarketDayHigh?: number | null
+  fiftyTwoWeekLow?: number | null
+  fiftyTwoWeekHigh?: number | null
+  marketCap?: number | null
+  regularMarketVolume?: number | null
+  averageDailyVolume3Month?: number | null
+  regularMarketOpen?: number | null
+  regularMarketPreviousClose?: number | null
+  trailingEps?: number | null
+  trailingPE?: number | null
+  fullExchangeName?: string | null
+  currency?: string | null
+  regularMarketTime?: number | null
+  postMarketPrice?: number | null
+  postMarketChange?: number | null
+  postMarketChangePercent?: number | null
+  preMarketPrice?: number | null
+  preMarketChange?: number | null
+  preMarketChangePercent?: number | null
+  hasPrePostMarketData?: boolean
+}
+
+export interface QuoteSummary {
+  summaryDetail?: {
+    open?: number | null
+    dayHigh?: number | null
+    dayLow?: number | null
+    volume?: number | null
+    trailingPE?: number | null
+    marketCap?: number | null
+    fiftyTwoWeekHigh?: number | null
+    fiftyTwoWeekLow?: number | null
+    averageVolume?: number | null
+    dividendYield?: number | null
+    beta?: number | null
+  }
+  defaultKeyStatistics?: {
+    trailingEps?: number | null
+  }
+  summaryProfile?: {
+    longBusinessSummary?: string | null
+    sector?: string | null
+    industryDisp?: string | null
+    country?: string | null
+    fullTimeEmployees?: number | null
+    website?: string | null
+  }
+}


### PR DESCRIPTION
## Summary
- define a reusable Yahoo Finance Quote interface in the shared types module
- update FMP quote helpers and markets table columns to consume the shared type instead of deep node_modules imports
- ensure quote summary fallbacks rely on the shared types to avoid build-time import errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3c3e6013c8321a20440b45f610060